### PR TITLE
Fedora patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Release/
+/Source/DoxyGen/html
+/Platform/Linux-x86/Bin
+/Platform/Linux-x86/CreateRedist/Final
+/Platform/Linux-x86/CreateRedist/Output
+/Platform/Linux-x86/Redist

--- a/Platform/Linux-x86/Build/CommonMakefile
+++ b/Platform/Linux-x86/Build/CommonMakefile
@@ -48,6 +48,9 @@ SRC_FILES_LIST = $(wildcard $(SRC_FILES))
 
 OSTYPE := $(shell uname -s)
 
+# add CFLAGS that have been passed in
+CFLAGS += $(CFLAGS_EXT)
+
 # change c struct alignment options to be compatable with Win32
 ifneq ("$(OSTYPE)","Darwin")
 	CFLAGS += -malign-double

--- a/Platform/Linux-x86/Build/CommonMakefile
+++ b/Platform/Linux-x86/Build/CommonMakefile
@@ -147,11 +147,15 @@ ifeq "$(CFG)" "Release"
 		ifeq ($(SSE_GENERATION), 3)
 			CFLAGS += -msse3
 		else
-			($error "Only SSE2 and SSE3 are supported")
+			$(error "Only SSE2 and SSE3 are supported")
 		endif
 	endif
 	
 	CSFLAGS += -o+
+endif
+
+ifeq ($(DEBUG),1)
+  CFLAGS += -g
 endif
 
 CFLAGS += $(INC_DIRS_OPTION) $(DEFINES_OPTION)

--- a/Platform/Linux-x86/Build/Modules/nimCodecs/Makefile
+++ b/Platform/Linux-x86/Build/Modules/nimCodecs/Makefile
@@ -2,16 +2,21 @@ BIN_DIR = ../../../Bin
 
 INC_DIRS = \
 	../../../../../Include \
-	../../../../../Source \
-	../../../../../Source/External/LibJPEG
+	../../../../../Source
 
 SRC_FILES = \
-	../../../../../Source/Modules/nimCodecs/*.cpp \
-	../../../../../Source/External/LibJPEG/*.c
+	../../../../../Source/Modules/nimCodecs/*.cpp
 
 LIB_NAME = nimCodecs
 USED_LIBS = OpenNI
 
+ifneq ($(wildcard /usr/lib/libjpeg.so /usr/lib32/libjpeg.so /usr/lib64/libjpeg.so /usr/local/lib/libjpeg.so /usr/local/lib32/libjpeg.so /usr/local/lib64/libjpeg.so),)
+  USED_LIBS += jpeg
+else
+  INC_DIRS  += ../../../../../Source/External/LibJPEG
+  SRC_FILES += ../../../../../Source/External/LibJPEG/*.c
+endif
+  
 include ../../CommonMakefile
 
 

--- a/Platform/Linux-x86/Build/OpenNI/Makefile
+++ b/Platform/Linux-x86/Build/OpenNI/Makefile
@@ -4,13 +4,11 @@ BIN_DIR = ../../Bin
 
 INC_DIRS = \
 	../../../../Include \
-	../../../../Source \
-	../../../../Source/External/TinyXml
+	../../../../Source
 
 SRC_FILES = \
 	../../../../Source/OpenNI/*.cpp \
-	../../../../Source/OpenNI/Linux-x86/*.cpp \
-	../../../../Source/External/TinyXml/*.cpp
+	../../../../Source/OpenNI/Linux-x86/*.cpp
 
 ifeq ("$(OSTYPE)","Darwin")
 	INC_DIRS += /opt/local/include
@@ -24,6 +22,13 @@ ifneq ("$(OSTYPE)","Darwin")
 	USED_LIBS += rt
 endif
 DEFINES = XN_EXPORTS
+
+ifneq ($(wildcard /usr/include/tinyxml.h /usr/local/include/tinyxml.h),)
+  USED_LIBS += tinyxml
+else
+  INC_DIRS += ../../../../Source/External/TinyXml
+  SRC_FILES += ../../../../Source/External/TinyXml/*.cpp
+endif
 
 include ../CommonMakefile
 

--- a/Platform/Linux-x86/Build/Samples/NiSimpleViewer/Makefile
+++ b/Platform/Linux-x86/Build/Samples/NiSimpleViewer/Makefile
@@ -11,7 +11,7 @@ EXE_NAME = Sample-NiSimpleViewer
 ifeq ("$(OSTYPE)","Darwin")
 	LDFLAGS += -framework OpenGL -framework GLUT
 else
-	USED_LIBS += glut
+	USED_LIBS += glut GL
 endif
 
 USED_LIBS += OpenNI

--- a/Platform/Linux-x86/Build/Samples/NiUserTracker/Makefile
+++ b/Platform/Linux-x86/Build/Samples/NiUserTracker/Makefile
@@ -11,7 +11,7 @@ EXE_NAME = Sample-NiUserTracker
 ifeq ("$(OSTYPE)","Darwin")
 	LDFLAGS += -framework OpenGL -framework GLUT
 else
-	USED_LIBS += glut
+	USED_LIBS += glut GL
 endif
 
 USED_LIBS += OpenNI

--- a/Platform/Linux-x86/Build/Samples/NiViewer/Makefile
+++ b/Platform/Linux-x86/Build/Samples/NiViewer/Makefile
@@ -11,7 +11,7 @@ SRC_FILES = ../../../../../Samples/NiViewer/*.cpp
 ifeq ("$(OSTYPE)","Darwin")
 	LDFLAGS += -framework OpenGL -framework GLUT
 else
-	USED_LIBS += glut
+	USED_LIBS += glut GL
 endif
 
 USED_LIBS += OpenNI


### PR DESCRIPTION
This set of patches makes OpenNI suitable for packaging in Fedora. The patch set has been included in a package review request filed at https://bugzilla.redhat.com/show_bug.cgi?id=674006.

Please consider integrating the set of patches to make future updates of the Fedora package easier.
