### PR TITLE
Overwriting config path for OpenNI

### DIFF
--- a/Platform/Linux-x86/Build/CommonMakefile
+++ b/Platform/Linux-x86/Build/CommonMakefile
@@ -50,11 +50,16 @@ OSTYPE := $(shell uname -s)
 
 # change c struct alignment options to be compatable with Win32
 ifneq ("$(OSTYPE)","Darwin")
-	CFLAGS += -malign-double
+	#CFLAGS += -malign-double
 else
 	CFLAGS += -arch i386 -arch x86_64
 	LDFLAGS += -arch i386 -arch x86_64
 endif
+
+CFLAGS += -I/software/tools/include/libusb/1.0.8
+LDFLAGS += -L../../../Bin/Release
+LDFLAGS += -L/software/tools/lib/cent5.x86_64/gcc/4.1.2
+USED_LIBS += usb-1.0
 
 # tell compiler to use the target system root
 ifneq ("$(TARGET_SYS_ROOT)","/")

--- a/Platform/Linux-x86/Build/CommonMakefile
+++ b/Platform/Linux-x86/Build/CommonMakefile
@@ -50,16 +50,11 @@ OSTYPE := $(shell uname -s)
 
 # change c struct alignment options to be compatable with Win32
 ifneq ("$(OSTYPE)","Darwin")
-	#CFLAGS += -malign-double
+	CFLAGS += -malign-double
 else
 	CFLAGS += -arch i386 -arch x86_64
 	LDFLAGS += -arch i386 -arch x86_64
 endif
-
-CFLAGS += -I/software/tools/include/libusb/1.0.8
-LDFLAGS += -L../../../Bin/Release
-LDFLAGS += -L/software/tools/lib/cent5.x86_64/gcc/4.1.2
-USED_LIBS += usb-1.0
 
 # tell compiler to use the target system root
 ifneq ("$(TARGET_SYS_ROOT)","/")

--- a/Source/OpenNI/XnLicensing.cpp
+++ b/Source/OpenNI/XnLicensing.cpp
@@ -138,8 +138,19 @@ XnStatus resolveLicensesFile(XnChar* strFileName, XnUInt32 nBufSize)
 		XN_IS_STATUS_OK(nRetVal);
 	#endif
 #elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_MACOSX)
-	nRetVal = xnOSStrCopy(strFileName, "/var/lib/ni/licenses.xml", nBufSize);
-	XN_IS_STATUS_OK(nRetVal);
+	char *pathVar = getenv( "OPEN_NI_CONFIG_PATH" );
+	if ( pathVar )
+	{
+		nRetVal = xnOSStrCopy(strFileName, pathVar, nBufSize);
+		XN_IS_STATUS_OK(nRetVal);
+		nRetVal = xnOSStrAppend( strFileName, "/licenses.xml", nBufSize );
+		XN_IS_STATUS_OK(nRetVal);
+	}
+	else
+	{
+		nRetVal = xnOSStrCopy(strFileName, "/var/lib/ni/licenses.xml", nBufSize);
+		XN_IS_STATUS_OK(nRetVal);
+	}
 #else
 	nRetVal = xnOSStrCopy(strFileName, "licenses.xml", nBufSize);
 	XN_IS_STATUS_OK(nRetVal);

--- a/Source/OpenNI/XnModuleLoader.cpp
+++ b/Source/OpenNI/XnModuleLoader.cpp
@@ -150,8 +150,19 @@ XnStatus resolveModulesFile(XnChar* strFileName, XnUInt32 nBufSize)
 		XN_IS_STATUS_OK(nRetVal);
 	#endif
 #elif (XN_PLATFORM == XN_PLATFORM_LINUX_X86 || XN_PLATFORM == XN_PLATFORM_LINUX_ARM || XN_PLATFORM == XN_PLATFORM_MACOSX)
-	nRetVal = xnOSStrCopy(strFileName, "/var/lib/ni/modules.xml", nBufSize);
-	XN_IS_STATUS_OK(nRetVal);
+	char *pathVar = getenv( "OPEN_NI_CONFIG_PATH" );
+	if ( pathVar )
+	{
+		nRetVal = xnOSStrCopy(strFileName, pathVar, nBufSize);
+		XN_IS_STATUS_OK(nRetVal);
+		nRetVal = xnOSStrAppend( strFileName, "/modules.xml", nBufSize );
+		XN_IS_STATUS_OK(nRetVal);
+	}
+	else
+	{
+		nRetVal = xnOSStrCopy(strFileName, "/var/lib/ni/modules.xml", nBufSize);
+		XN_IS_STATUS_OK(nRetVal);
+	}
 #elif XN_PLATFORM_SUPPORTS_DYNAMIC_LIBS
 	#error "Module Loader is not supported on this platform!"
 #endif


### PR DESCRIPTION
The changes affect OpenNI in linux and MacOS only. I'm using the environment variable named OPEN_NI_CONFIG_PATH to overwrite the default path for the config files modules.xml and license.xml.

Ideally I would use the OPEN_NI_INSTALL_PATH variable used in Windows, but it implies a different directory structure.
