### PR TITLE
Patch for Seg Fault in NiSimpleViewer

### DIFF
--- a/Samples/NiSimpleViewer/NiSimpleViewer.cpp
+++ b/Samples/NiSimpleViewer/NiSimpleViewer.cpp
@@ -260,8 +260,18 @@ int main(int argc, char* argv[])
 	}
 
 	rc = g_context.FindExistingNode(XN_NODE_TYPE_DEPTH, g_depth);
+        if (rc != XN_STATUS_OK)
+	{
+		printf("Find Depth Generator Failed: %s\n", xnGetStatusString(rc));
+		return (rc);
+	}
+    
 	rc = g_context.FindExistingNode(XN_NODE_TYPE_IMAGE, g_image);
-
+        if (rc != XN_STATUS_OK)
+	{
+		printf("Find Image Generator Failed: %s\n", xnGetStatusString(rc));
+		return (rc);
+	}
 	g_depth.GetMetaData(g_depthMD);
 	g_image.GetMetaData(g_imageMD);
 


### PR DESCRIPTION
Edited NiSimpleViewer.cpp so that it does not Seg Fault with the Asus XTion node. The issue with the existing file is that it creates a depth node and an image node without verifying that the returned status == XN_STATUS_OK, then tries to call functions on a null pointer.
