### PR TITLE
Copy to buffer

### DIFF
--- a/Wrappers/OpenNI.java/src/org/OpenNI/Map.java
+++ b/Wrappers/OpenNI.java/src/org/OpenNI/Map.java
@@ -35,6 +35,17 @@ public class Map
 		NativeMethods.copyToBuffer(buffer, this.ptr, size);
 		return buffer;
 	}
+	
+	/**
+	 * Copies the data to a preallocated buffer.
+	 * 
+	 * @param buffer preallocated ByteBuffer with size greater than or equal to 
+	 *     the number of bytes need to be copied.
+	 * @param size number of bytes to copy.
+	 */
+	public void copyToBuffer(ByteBuffer buffer, int size) {
+	  NativeMethods.copyToBuffer(buffer, this.ptr, size);
+	}
 
 	protected long getPixelPtr(int x, int y) 
 	{ 


### PR DESCRIPTION
Added a new method copyToBuffer for copying data to a preallocated buffer to prevent memory drain. This is for addressing issue #39.
