### PR TITLE
Fix symbol conflict with std library

### DIFF
--- a/Samples/NiViewer/glh/glh_linear.h
+++ b/Samples/NiViewer/glh/glh_linear.h
@@ -77,7 +77,7 @@ glh_linear.h
 #define     GLH_EPSILON         GLH_REAL(10e-6)
 #define     GLH_PI              GLH_REAL(3.1415926535897932384626433832795)    
 
-#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
+#define     my_equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
 
 namespace glh
 {
@@ -1093,7 +1093,7 @@ namespace glh
 
         real norm = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
 
-        s = (equivalent(norm,GLH_ZERO)) ? GLH_ZERO : ( GLH_TWO / norm );
+        s = (my_equivalent(norm,GLH_ZERO)) ? GLH_ZERO : ( GLH_TWO / norm );
 
         xs = q[0] * s;
         ys = q[1] * s;
@@ -1194,7 +1194,7 @@ namespace glh
             theta *= real(0.5);
             real sin_theta = real(sin(theta));
 
-            if (!equivalent(sqnorm,GLH_ONE)) 
+            if (!my_equivalent(sqnorm,GLH_ONE)) 
               sin_theta /= real(sqrt(sqnorm));
             x = sin_theta * axis.v[0];
             y = sin_theta * axis.v[1];
@@ -1216,14 +1216,14 @@ namespace glh
 
         alpha = p1.dot(p2);
 
-        if(equivalent(alpha,GLH_ONE))
+        if(my_equivalent(alpha,GLH_ONE))
         { 
             *this = identity(); 
             return *this; 
         }
 
         // ensures that the anti-parallel case leads to a positive dot
-        if(equivalent(alpha,-GLH_ONE))
+        if(my_equivalent(alpha,-GLH_ONE))
         {
             vec3 v;
 
@@ -1280,7 +1280,7 @@ namespace glh
     void normalize()
     {
         real rnorm = GLH_ONE / real(sqrt(w * w + x * x + y * y + z * z));
-        if (equivalent(rnorm, GLH_ZERO))
+        if (my_equivalent(rnorm, GLH_ZERO))
             return;
         x *= rnorm;
         y *= rnorm;
@@ -1439,10 +1439,10 @@ namespace glh
     inline
     bool operator == ( const quaternion & q1, const quaternion & q2 )
     {
-        return (equivalent(q1.x, q2.x) &&
-		        equivalent(q1.y, q2.y) &&
-		        equivalent(q1.z, q2.z) &&
-		        equivalent(q1.w, q2.w) );
+        return (my_equivalent(q1.x, q2.x) &&
+		        my_equivalent(q1.y, q2.y) &&
+		        my_equivalent(q1.z, q2.z) &&
+		        my_equivalent(q1.w, q2.w) );
     }
 
     inline


### PR DESCRIPTION
On Ubuntu 18.04, build fails because of this symbol conflict with name "equivalent". 
The solution is to rename it with something else.