### PR TITLE
fixed compilation problems on linux (ansi or std options)

### DIFF
--- a/Externals/LibJPEG/jconfig.h
+++ b/Externals/LibJPEG/jconfig.h
@@ -2,7 +2,7 @@
 	#include "jconfig.vc"
 #elif SN_TARGET_PS3
 	#include "jconfig.ps3"
-#elif ((linux) || (__APPLE__))
+#elif ((__linux__) || (__APPLE__))
 	#include "jconfig.lnx86"
 #elif (_ARC)
 	#include "jconfig.lnx86"

--- a/Include/XnPlatform.h
+++ b/Include/XnPlatform.h
@@ -61,9 +61,9 @@
 	#include "Win32/XnPlatformWin32.h"
 #elif defined(ANDROID) && defined(__arm__)
 	#include "Android-Arm/XnPlatformAndroid-Arm.h"
-#elif (linux && (i386 || __x86_64__))
+#elif (__linux__ && (__i386__ || __x86_64__))
 	#include "Linux-x86/XnPlatformLinux-x86.h"
-#elif (linux && __arm__)
+#elif (__linux__ && __arm__)
 	#include "Linux-Arm/XnPlatformLinux-Arm.h"
 #elif _ARC
 	#include "ARC/XnPlatformARC.h"


### PR DESCRIPTION
Thanks @dennis-hamester for the original pull-request #74 fixing the wrong macro checks.

> Externals/LibJPEG/jconfig.h and Include/XnPlatform.h use wrong macros to check for linux.
> See: http://gcc.gnu.org/onlinedocs/cpp/System_002dspecific-Predefined-Macros.html#System_002dspecific-Predefined-Macros

The original pull request #74 contained some patching-mistakes (wrong line-numbers and endings). This patch fixes those errors and can be applied as expected.

Applying this patch also fixes a compilation error with `pcl` + `openni` as commented about here: https://aur.archlinux.org/packages/pcl